### PR TITLE
Fix the issue that it cannot use in Xcode 7.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,35 +1,49 @@
 # Xcode-Multi-Edit-Plugin
 
 <h3>Overview</h3>
+
 This is the public repo for the Multi Edit Xcode plugin. This plugin allows developers to quickly and easily edit multiple instances of a selected term in a source document. This is a feature borrowed from many professional text editors, such as Sublime Text.
 
 Examples:
+
 <br>
+
 <br>
+
 ![](img/one.gif)
+
 <br>
+
 <br>
+
 ![](img/two.gif)
 
 <h3>Installation</h3>
+
 The plugin can be installed easily through the [Alcatraz Plugin Manager](http://alcatraz.io)
+
  for Xcode, or installed manually by simply downloading or cloning the repo and running the project.
 
 <h3>Usage</h3>
 
-<b>Shift-Option-D</b>: Include next instance of the selected term<br>
-<b>Shift-Option-U</b>: Undo the last selection<br>
-<b>Shift-Option-K</b>: Undo the last selection and select the next instance<br>
+<b>Shift-Option-A</b>: Include next instance of the selected term<br>
+
+<b>Shift-Option-Z</b>: Undo the last selection<br>
+
+<b>Shift-Option-S</b>: Undo the last selection and select the next instance<br>
 
 Then simply type out your replacement text and hit enter.
 
 <h3>Requirements</h3>
 
 <h5>Xcode v7.0+</h5>
+
 May work on earlier versions but has not been tested. If you experience problems try updating to the latest version.
 
 <h3>Contributions</h3>
+
 This plugin is not heavily tested and so if you encounter errors or problems please open an issue. We welcome pull requests, so if you feel like contributing get involved!
 
 <h3>Author</h3>
+
 Developed and maintained by Tim Edwards ([@timwredwards](https://twitter.com/timwredwards))

--- a/Xcode Multi Edit.xcodeproj/project.pbxproj
+++ b/Xcode Multi Edit.xcodeproj/project.pbxproj
@@ -7,11 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		1C91B0ED1BCEA3A600A6EBD7 /* MultiEditContext.m in Sources */ = {isa = PBXBuildFile; fileRef = 1C91B0EC1BCEA3A600A6EBD7 /* MultiEditContext.m */; settings = {ASSET_TAGS = (); }; };
-		1CA36E821BCDFE28009503E6 /* MultiEditView.m in Sources */ = {isa = PBXBuildFile; fileRef = 1CA36E811BCDFE28009503E6 /* MultiEditView.m */; settings = {ASSET_TAGS = (); }; };
+		1C91B0ED1BCEA3A600A6EBD7 /* MultiEditContext.m in Sources */ = {isa = PBXBuildFile; fileRef = 1C91B0EC1BCEA3A600A6EBD7 /* MultiEditContext.m */; };
+		1CA36E821BCDFE28009503E6 /* MultiEditView.m in Sources */ = {isa = PBXBuildFile; fileRef = 1CA36E811BCDFE28009503E6 /* MultiEditView.m */; };
 		226268A11AA55B2500ABBBB2 /* AppKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 226268A01AA55B2500ABBBB2 /* AppKit.framework */; };
 		226268A31AA55B2500ABBBB2 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 226268A21AA55B2500ABBBB2 /* Foundation.framework */; };
-		226268A81AA55B2500ABBBB2 /* XcodeMultiEdit.xcodeproj in Resources */ = {isa = PBXBuildFile; fileRef = 226268A71AA55B2500ABBBB2 /* XcodeMultiEdit.xcodeproj */; };
 		226268AB1AA55B2500ABBBB2 /* MultiEdit.m in Sources */ = {isa = PBXBuildFile; fileRef = 226268AA1AA55B2500ABBBB2 /* MultiEdit.m */; };
 /* End PBXBuildFile section */
 
@@ -26,7 +25,6 @@
 		226268A01AA55B2500ABBBB2 /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = /System/Library/Frameworks/AppKit.framework; sourceTree = "<absolute>"; };
 		226268A21AA55B2500ABBBB2 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = /System/Library/Frameworks/Foundation.framework; sourceTree = "<absolute>"; };
 		226268A61AA55B2500ABBBB2 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		226268A71AA55B2500ABBBB2 /* XcodeMultiEdit.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; path = XcodeMultiEdit.xcodeproj; sourceTree = SOURCE_ROOT; };
 		226268AA1AA55B2500ABBBB2 /* MultiEdit.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MultiEdit.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -43,11 +41,6 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		1C73A9731BCCB66A00BC198E /* Products */ = {
-			isa = PBXGroup;
-			name = Products;
-			sourceTree = "<group>";
-		};
 		226268941AA55B2500ABBBB2 = {
 			isa = PBXGroup;
 			children = (
@@ -94,7 +87,6 @@
 			isa = PBXGroup;
 			children = (
 				226268A61AA55B2500ABBBB2 /* Info.plist */,
-				226268A71AA55B2500ABBBB2 /* XcodeMultiEdit.xcodeproj */,
 			);
 			name = "Supporting Files";
 			sourceTree = "<group>";
@@ -133,7 +125,7 @@
 					};
 				};
 			};
-			buildConfigurationList = 226268981AA55B2500ABBBB2 /* Build configuration list for PBXProject "XcodeMultiEdit" */;
+			buildConfigurationList = 226268981AA55B2500ABBBB2 /* Build configuration list for PBXProject "Xcode Multi Edit" */;
 			compatibilityVersion = "Xcode 3.2";
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
@@ -143,12 +135,6 @@
 			mainGroup = 226268941AA55B2500ABBBB2;
 			productRefGroup = 2262689E1AA55B2500ABBBB2 /* Products */;
 			projectDirPath = "";
-			projectReferences = (
-				{
-					ProductGroup = 1C73A9731BCCB66A00BC198E /* Products */;
-					ProjectRef = 226268A71AA55B2500ABBBB2 /* XcodeMultiEdit.xcodeproj */;
-				},
-			);
 			projectRoot = "";
 			targets = (
 				2262689C1AA55B2500ABBBB2 /* XcodeMultiEdit */,
@@ -161,7 +147,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				226268A81AA55B2500ABBBB2 /* XcodeMultiEdit.xcodeproj in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -286,7 +271,7 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		226268981AA55B2500ABBBB2 /* Build configuration list for PBXProject "XcodeMultiEdit" */ = {
+		226268981AA55B2500ABBBB2 /* Build configuration list for PBXProject "Xcode Multi Edit" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				226268AC1AA55B2500ABBBB2 /* Debug */,

--- a/XcodeMultiEdit/Info.plist
+++ b/XcodeMultiEdit/Info.plist
@@ -22,13 +22,6 @@
 	<string>????</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
-	<key>DVTPlugInCompatibilityUUIDs</key>
-	<array>
-		<string>C4A681B0-4A26-480E-93EC-1218098B9AA0</string>
-		<string>AD68E85B-441B-4301-B564-A45E4919A6AD</string>
-		<string>7FDF5C7A-131F-4ABB-9EDC-8C5F8F0B8A90</string>
-		<string>0420B86A-AA43-4792-9ED0-6FE0F2B16A13</string>
-	</array>
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>NSPrincipalClass</key>
@@ -37,5 +30,25 @@
 	<true/>
 	<key>XCPluginHasUI</key>
 	<false/>
+	<key>DVTPlugInCompatibilityUUIDs</key>
+	<array>
+		<string>FEC992CC-CA4A-4CFD-8881-77300FCB848A</string>
+		<string>C4A681B0-4A26-480E-93EC-1218098B9AA0</string>
+		<string>A2E4D43F-41F4-4FB9-BB94-7177011C9AED</string>
+		<string>AD68E85B-441B-4301-B564-A45E4919A6AD</string>
+		<string>63FC1C47-140D-42B0-BB4D-A10B2D225574</string>
+		<string>37B30044-3B14-46BA-ABAA-F01000C27B63</string>
+		<string>640F884E-CE55-4B40-87C0-8869546CAB7A</string>
+		<string>992275C1-432A-4CF7-B659-D84ED6D42D3F</string>
+		<string>A16FF353-8441-459E-A50C-B071F53F51B7</string>
+		<string>9F75337B-21B4-4ADC-B558-F9CADF7073A7</string>
+		<string>E969541F-E6F9-4D25-8158-72DC3545A6C6</string>
+		<string>8DC44374-2B35-4C57-A6FE-2AD66A36AAD9</string>
+		<string>AABB7188-E14E-4433-AD3B-5CD791EAD9A3</string>
+		<string>7FDF5C7A-131F-4ABB-9EDC-8C5F8F0B8A90</string>
+		<string>0420B86A-AA43-4792-9ED0-6FE0F2B16A13</string>
+		<string>CC0D0F4F-05B3-431A-8F33-F84AFCB2C651</string>
+		<string>7265231C-39B4-402C-89E1-16167C4CC990</string>
+	</array>
 </dict>
 </plist>

--- a/XcodeMultiEdit/MultiEdit.m
+++ b/XcodeMultiEdit/MultiEdit.m
@@ -89,13 +89,13 @@ static int kMultiEditContextKey;
 }
 
 -(void)setSubmenuKeyEquivalents{
-    [[multiEditSubmenu itemAtIndex:0] setKeyEquivalent:@"d"];
+    [[multiEditSubmenu itemAtIndex:0] setKeyEquivalent:@"a"];
     [[multiEditSubmenu itemAtIndex:0] setKeyEquivalentModifierMask:NSShiftKeyMask | NSAlternateKeyMask];
     
-    [[multiEditSubmenu itemAtIndex:1] setKeyEquivalent:@"u"];
+    [[multiEditSubmenu itemAtIndex:1] setKeyEquivalent:@"z"];
     [[multiEditSubmenu itemAtIndex:1] setKeyEquivalentModifierMask:NSShiftKeyMask | NSAlternateKeyMask];
     
-    [[multiEditSubmenu itemAtIndex:2] setKeyEquivalent:@"k"];
+    [[multiEditSubmenu itemAtIndex:2] setKeyEquivalent:@"s"];
     [[multiEditSubmenu itemAtIndex:2] setKeyEquivalentModifierMask:NSShiftKeyMask | NSAlternateKeyMask];
 }
 


### PR DESCRIPTION
Fix the issue that it cannot use in Xcode 7.1
Change the shortcuts.
shift+opt+a : include
shift+opt+s : skip and include next
shift+opt+z : undo
Doing this because “D”, “U”, “K” are far away from one hand operation.
